### PR TITLE
Updates to tidy code, fix pgm_read_byte_far() for xmega.

### DIFF
--- a/BootFramXM256x3/Makefile
+++ b/BootFramXM256x3/Makefile
@@ -269,6 +269,8 @@ else ifeq ($(LCD), ST7567)
   CDEFS += -DLCD_ST7567
 else ifeq ($(LCD), ST7565P)
   CDEFS += -DLCD_ST7565P
+else
+  $(error Sorry, the LCD $(LCD) is not supported yet)
 endif
 
 

--- a/BootFramXM256x3/conf/m2560fram.conf.mk
+++ b/BootFramXM256x3/conf/m2560fram.conf.mk
@@ -93,8 +93,11 @@ ENABLE_EEPROM_PROTECTION = no
 ENABLE_BOOTLOADER_PROTECTION = no
 
 # ENTER_PIN
-# Left hand stick - horzontal right trim button.
-ENTER_PORT_NAME       = F
+# Left Gimbal Trims - Right trim button.
+#ENTER_PORT_NAME       = F
+#ENTER_PIN             = 6
+# Elevator Dual Rate Switch
+ENTER_PORT_NAME       = L
 ENTER_PIN             = 6
 ENTER_PIN_STATE       = 0
 ENTER_PIN_PUEN        = yes

--- a/BootFramXM256x3/conf/x256x3fram.conf.mk
+++ b/BootFramXM256x3/conf/x256x3fram.conf.mk
@@ -125,6 +125,7 @@ ENABLE_EEPROM_PROTECTION = no
 ENABLE_BOOTLOADER_PROTECTION = no
 
 # ENTER_PIN
+# Left Gimbal Trims - Right trim button.
 ENTER_PORT_NAME       = E
 ENTER_PIN             = 4
 ENTER_PIN_STATE       = 0

--- a/BootFramXM256x3/lcd/lcd_default_driver.c
+++ b/BootFramXM256x3/lcd/lcd_default_driver.c
@@ -33,11 +33,10 @@
 static void lcdRefreshFast(void);
 
 
-
 #define NUMITERATIONFULLREFRESH  1
 
 
-static void lcdSendCtl(uint8_t val)
+static void lcdSendCmd(uint8_t val)
 {
   PORTC_LCD_CTRL &= ~_BV(OUT_C_LCD_CS1);
 #if defined(LCD_MULTIPLEX)
@@ -55,7 +54,7 @@ static void lcdSendCtl(uint8_t val)
   PORTC_LCD_CTRL |=  _BV(OUT_C_LCD_CS1);
 }
 
-const static uint8_t lcdInitSequence[] PROGMEM = {
+static const uint8_t lcdInitSequence[] PROGMEM = {
   //ST7565 eq. : KS0713, SED1565, S6B1713, SPLC501C, NT7532 /34 /38, TL03245
 #if defined(LCD_ST7565R)
   0xE2, //Initialize the internal functions
@@ -84,36 +83,32 @@ const static uint8_t lcdInitSequence[] PROGMEM = {
   0x81, //Set reference voltage Mode
   0x2D, //24 SV5 SV4 SV3 SV2 SV1 SV0
   0xAF  //DON = 1: display ON
-/*
 #elif defined(LCD_LT13264B) // SPLC501C 132x64 Inverse.
   0xE2, // CMD_RESET
   0xAE, // CMD_DISPLAY_OFF
   0xA1, // CMD_REVERSE_SEG_DIRECTION
-  0xA7, // CMD_DISPLAY_INVERT
+  0xA6, // ST756n_CMD_DISPLAY_NORMAL
   0xA4, // CMD_DISPLAY_ALL_POINTS_OFF
   0xA2, // CMD_BIAS_SELECT_9TH
   0xC0, // CMD_NORMAL_COM_DIRECTION
   0x2F, // CMD_POWER_CTRL
-  //0x24, // *** Use default 0x24 *** CMD_VOLTAGE_RESISTOR_RATIO ***
+  0x24, // *** Use default 0x24 *** CMD_VOLTAGE_RESISTOR_RATIO ***
   0x81, // CMD_CONTRAST_SET
-  CONTRAST_MIN, // Contrast value.
+  CONTRAST_MIN,  // Contrast value.
   0xAF  // CMD_DISPLAY_ON
-*/
-#else   //ST7565P (default 9x LCD) also LCD_LT13264B (SPLC501C 132x64 Inverse).
-  0xE2, //Initialize the internal functions
-  0xAE, //DON = 0: display OFF
-  0xA1, //ADC = 1: reverse direction(SEG132->SEG1)
-  0xA6, //REV = 0: non-reverse display
-  0xA4, //EON = 0: normal display. non-entire
-  0xA2, //Select LCD bias=0
-  0xC0, //SHL = 0: normal direction (COM1->COM64)
+#else   //ST7565P (default 9x LCD)
+  0xE2, //ST756n_CMD_RESET
+  0xAE, //ST756n_CMD_DISPLAY_OFF
+  0xA1, //ST756n_CMD_REVERSE_SEG_DIRECTION (SEG132->SEG1)
+  0xA6, //ST756n_CMD_DISPLAY_NORMAL
+  0xA4, //ST756n_CMD_DISPLAY_ALL_POINTS_OFF
+  0xA2, //ST756n_CMD_BIAS_SELECT_9TH
+  0xC0, //ST756n_CMD_NORMAL_COM_DIRECTION (COM1->COM64)
   0x2F, //Control power circuit operation VC=VR=VF=1
-  //0x24, // *** Use default 0x24 *** CMD_VOLTAGE_RESISTOR_RATIO ***
-  //0x25, //Select int resistance ratio R2 R1 R0 =5
-  0x81, //Set reference voltage Mode
-  CONTRAST_MIN, // Contrast value.
-  //0x22, //24 SV5 SV4 SV3 SV2 SV1 SV0 = 0x18
-  0xAF  //DON = 1: display ON
+  0x25, //ST756n_CMD_VOLTAGE_RESISTOR_RATIO_5dec5
+  0x81, //ST756n_CMD_CONTRAST_SET
+  0x22, //// Contrast value.
+  0xAF  //ST756n_CMD_DISPLAY_ON
 #endif
 };
 
@@ -123,9 +118,12 @@ void lcdInit()
   _delay_us(2);
   PORTC_LCD_CTRL |= _BV(OUT_C_LCD_RES);  //LCD normal operation
   _delay_us(1500);
+
+  uint_farptr_t initseq = pgm_get_far_address(lcdInitSequence);
   for (uint8_t i=0; i<DIM(lcdInitSequence); i++) {
-    lcdSendCtl(pgm_read_byte_far(&lcdInitSequence[i]));
+    lcdSendCmd(pgm_read_byte_far(initseq++));
   }
+
 #if defined(LCD_ERC12864FSF)
 //  g_eeGeneral.contrast = 0x2D;
 #else
@@ -135,8 +133,8 @@ void lcdInit()
 
 static void lcdSetRefVolt(uint8_t val)
 {
-  lcdSendCtl(0x81);
-  lcdSendCtl(val);
+  lcdSendCmd(0x81);
+  lcdSendCmd(val);
 }
 
 static void lcdRefreshFast()
@@ -148,14 +146,14 @@ SHOWDURATIONLCD1
   uint8_t * p = displayBuf;
   for (uint8_t y=0; y < 8; y++) {
 #if defined(LCD_ST7565R)
-    lcdSendCtl(0x01);
+    lcdSendCmd(0x01);
 #elif defined(LCD_SIZE_132X64)
-    lcdSendCtl(0x00);
+    lcdSendCmd(0x00);
 #else
-    lcdSendCtl(0x04);
+    lcdSendCmd(0x04);
 #endif
-    lcdSendCtl(0x10); // Column addr 0
-    lcdSendCtl( y | 0xB0); //Page addr y
+    lcdSendCmd(0x10); // Column addr 0
+    lcdSendCmd( y | 0xB0); //Page addr y
     PORTC_LCD_CTRL &= ~_BV(OUT_C_LCD_CS1);
 #if defined(LCD_MULTIPLEX)
     DDRA = 0xFF; // Set LCD_DAT pins to output
@@ -163,10 +161,10 @@ SHOWDURATIONLCD1
     PORTC_LCD_CTRL |=  _BV(OUT_C_LCD_A0);
     PORTC_LCD_CTRL &= ~_BV(OUT_C_LCD_RnW);
     #if defined (LCD_SIZE_132X64)
-    PORTA_LCD_DAT = (0x00); // Pad out the four unused columns.
+    PORTA_LCD_DAT = (0xff); // Pad out the four unused columns.
     PORTC_LCD_CTRL |= _BV(OUT_C_LCD_E);
     PORTC_LCD_CTRL &= ~_BV(OUT_C_LCD_E);
-    PORTA_LCD_DAT = (0x00);
+    PORTA_LCD_DAT = (0xff);
     PORTC_LCD_CTRL |= _BV(OUT_C_LCD_E);
     PORTC_LCD_CTRL &= ~_BV(OUT_C_LCD_E);
     #endif
@@ -176,10 +174,10 @@ SHOWDURATIONLCD1
       PORTC_LCD_CTRL &= ~_BV(OUT_C_LCD_E);
     }
     #if defined (LCD_SIZE_132X64)
-    PORTA_LCD_DAT = (0x00); // Pad out the four unused columns.
+    PORTA_LCD_DAT = (0xff);
     PORTC_LCD_CTRL |= _BV(OUT_C_LCD_E);
     PORTC_LCD_CTRL &= ~_BV(OUT_C_LCD_E);
-    PORTA_LCD_DAT = (0x00);
+    PORTA_LCD_DAT = (0xff);
     PORTC_LCD_CTRL |= _BV(OUT_C_LCD_E);
     PORTC_LCD_CTRL &= ~_BV(OUT_C_LCD_E);
     #endif
@@ -199,12 +197,12 @@ SHOWDURATIONLCD1
   uint8_t * p = displayBuf;
   for (uint8_t y=0; y < 8; y++) {
 #if defined(LCD_ST7565R)
-    lcdSendCtl(0x01);
+    lcdSendCmd(0x01);
 #else
-    lcdSendCtl(0x04);
+    lcdSendCmd(0x04);
 #endif
-    lcdSendCtl(0x10); // Column addr 0
-    lcdSendCtl( y | 0xB0); //Page addr y
+    lcdSendCmd(0x10); // Column addr 0
+    lcdSendCmd( y | 0xB0); //Page addr y
     PORTC_LCD_CTRL &= ~_BV(OUT_C_LCD_CS1);
 #if defined(LCD_MULTIPLEX)
     DDRA = 0xFF; // Set LCD_DAT pins to output

--- a/BootFramXM256x3/lcd/lcd_driver.c
+++ b/BootFramXM256x3/lcd/lcd_driver.c
@@ -31,10 +31,9 @@
 */
 #include "lcd/lcd.h"
 
-
 static void lcd_imgfar(coord_t x, coord_t y,  uint_farptr_t img, uint8_t idx, LcdFlags att);
 
-const uint8_t desktop_icon[] PROGMEM = {
+static const uint8_t desktop_icon[] PROGMEM = {
 #include "desktop.lbm"
 };
 

--- a/BootFramXM256x3/lcd/lcd_spi_driver.c
+++ b/BootFramXM256x3/lcd/lcd_spi_driver.c
@@ -29,8 +29,6 @@
 #include "lcd/lcd.h"
 static void lcdRefreshFast(void);
 
-static void lcdClearRAM(void);
-
 
 //#define LCD_SSD1309
 //#define LCD_EVO
@@ -93,6 +91,7 @@ static void lcdClearRAM(void);
 #define ST756n_CMD_VOLTAGE_RESISTOR_RATIO_6dec5    0x27
 
 #define ST756n_CMD_RESET                       0xE2
+#define ST756n_CMD_NOP                         0xE3
 #define ST756n_CMD_DISPLAY_ALL_POINTS_OFF      0xA4
 #define ST756n_CMD_DISPLAY_ALL_POINTS_ON       0xA5
 #define ST756n_CMD_DISPLAY_NORMAL              0xA6
@@ -242,6 +241,79 @@ static void lcdSetRefVolt(uint8_t val)
 }
 
 
+static const uint8_t lcdInitSequence[] PROGMEM = {
+
+#if defined(LCD_EVO) || defined(LCD_ST7567)
+  ST756n_CMD_RESET,
+  ST756n_CMD_NOP, // Try to add _delay_us(300) as original code.
+#if !defined (REVERSE_DISPLAY)
+  ST756n_CMD_NORMAL_SEG_DIRECTION,
+  ST756n_CMD_REVERSE_COM_DIRECTION,
+#else
+  ST756n_CMD_REVERSE_SEG_DIRECTION,
+  ST756n_CMD_NORMAL_COM_DIRECTION,
+#endif
+#if defined (LCD_ST7567)
+  ST756n_CMD_SET_BOOSTER_LEVEL);
+  0, // Set Booster Level 4x.
+  ST756n_CMD_BIAS_SELECT_7TH, // Select bias 1/7 (at 1/65 duty) not 1/9.
+  ST756n_CMD_VOLTAGE_RESISTOR_RATIO_4dec5, // Compromise setting although contrast value could be 20 or 40.
+#endif
+#if defined (LCD_EVO)
+  ST756n_CMD_VOLTAGE_RESISTOR_RATIO_5dec0,
+  ST756n_CMD_CONTRAST_SET,
+  20,
+#endif
+  ST756n_CMD_POWER_CTRL | 4,
+  ST756n_CMD_NOP,
+  ST756n_CMD_POWER_CTRL | 6,
+  ST756n_CMD_NOP,
+  ST756n_CMD_POWER_CTRL | 7,
+  ST756n_CMD_NOP,
+  ST756n_CMD_DISPLAY_ON,
+
+#elif defined(LCD_SSD1309)
+
+  SSD1309_CMD_SETCMDLOCK,  // Set Command Lock
+  0x12, // Unlock
+  //     0x12 => Driver IC interface is unlocked from entering command.
+  //     0x16 => All Commands are locked except 0xFD.
+  SSD1309_CMD_DISPLAYSLEEP,            //--turn off oled panel
+  SSD1309_CMD_SETDISPLAYCLOCKDIV, // Set Display Clock Divide Ratio / Oscillator Frequency
+  0x70,      //   Default => 0x70
+  //     D[3:0] => Display Clock Divider
+  //     D[7:4] => Oscillator Frequency
+  SSD1309_CMD_SETMULTIPLEX,         //--set multiplex ratio(1 to 64)
+  0x3f,            //--1/64 duty
+  SSD1309_CMD_SETDISPLAYOFFSET, //Set Display Offset
+  0x00,
+  SSD1309_CMD_SETSTARTLINE(0),      // Set Display Start Line
+  SSD1309_CMD_SETMEMORYADDRESSMODE,    // Set Memory Addressing Mode
+  0x02,     //   Default => 0x02
+  //     0x00 => Horizontal Addressing Mode
+  //     0x01 => Vertical Addressing Mode
+  //     0x02 => Page Addressing Mode  .. no increment between pages.
+  SSD1309_CMD_SETSEGMENTREMAPREV, //
+  SSD1309_CMD_SETCOMOUTPUTDIRREV, //
+  SSD1309_CMD_SETCOMPINSHARDCONF, //--Set COM Pins Hardware Configuration
+  0x12, //     Disable COM Left/Right Re-Map   Alternative COM Pin Configuration
+  SSD1309_CMD_SETPRECHARGE,      // Set Pre-Charge Period
+  0xAA, //   Default => 0x22 (2 Display Clocks [Phase 2] / 2 Display Clocks [Phase 1])
+  //     D[3:0] => Phase 1 Period (discharge) in 1~15 Display Clocks
+  //     D[7:4] => Phase 2 Period (charge) in 1~15 Display Clocks
+  SSD1309_CMD_SETVCOMDETECT,      // Set VCOMH Deselect Level
+  0x00,      // 34  Default => 0x34 (0.78*VCC)
+  SSD1309_CMD_NORMALDISPLAY, //--set normal display
+  SSD1309_CMD_DISPLAYALLON,  //Disable Entire Display On
+  SSD1309_CMD_DISPLAYWAKEUP, //--turn on oled panel
+  SSD1309_CMD_DISPLAYALLON_RESUME, // Turn on OLED panel
+  SSD1309_CMD_SETCONTRAST,
+  30,
+
+#endif
+};
+
+
 void lcdInit()
 {
   // Setup pin states and MSPI mode.
@@ -263,7 +335,7 @@ void lcdInit()
 
   LCD_PORT.DIRSET = O_LCD_CS | O_LCD_SCK_P | O_LCD_MOSI;
 
-  #if !defined (SPI9BIT) // 8 bit spi and bitbang.
+#if !defined (SPI9BIT) // 8 bit spi and bitbang.
   LCD_PORT.DIRSET = O_LCD_CMD_DATA;
 #endif
 
@@ -285,89 +357,11 @@ void lcdInit()
 
   _delay_us(300);
 
-#if defined (LCD_SSD1309)
-  lcdSendCmd(SSD1309_CMD_SETCMDLOCK);  // Set Command Lock
-  lcdSendCmd(0x12);  // Unlock
-  //     0x12 => Driver IC interface is unlocked from entering command.
-  //     0x16 => All Commands are locked except 0xFD.
-
-  lcdSendCmd(SSD1309_CMD_DISPLAYSLEEP);            //--turn off oled panel
-
-  lcdSendCmd(SSD1309_CMD_SETDISPLAYCLOCKDIV); // Set Display Clock Divide Ratio / Oscillator Frequency
-  lcdSendCmd(0x70);      //   Default => 0x70
-  //     D[3:0] => Display Clock Divider
-  //     D[7:4] => Oscillator Frequency
-
-  lcdSendCmd(SSD1309_CMD_SETMULTIPLEX);         //--set multiplex ratio(1 to 64)
-  lcdSendCmd(0x3f);            //--1/64 duty
-
-  lcdSendCmd(SSD1309_CMD_SETDISPLAYOFFSET); //Set Display Offset
-  lcdSendCmd(0x00);
-
-  lcdSendCmd(SSD1309_CMD_SETSTARTLINE(0));      // Set Display Start Line
-
-  lcdSendCmd(SSD1309_CMD_SETMEMORYADDRESSMODE);    // Set Memory Addressing Mode
-  lcdSendCmd(0x02);      //   Default => 0x02
-  //     0x00 => Horizontal Addressing Mode
-  //     0x01 => Vertical Addressing Mode
-  //     0x02 => Page Addressing Mode  .. no increment between pages.
-
-  lcdSendCmd(SSD1309_CMD_SETSEGMENTREMAPREV); //
-  lcdSendCmd(SSD1309_CMD_SETCOMOUTPUTDIRREV); //
-
-  lcdSendCmd(SSD1309_CMD_SETCOMPINSHARDCONF); //--Set COM Pins Hardware Configuration
-  lcdSendCmd(0x12); //     Disable COM Left/Right Re-Map   Alternative COM Pin Configuration
-
-  lcdSendCmd(SSD1309_CMD_SETPRECHARGE);      // Set Pre-Charge Period
-  lcdSendCmd(0xAA); //   Default => 0x22 (2 Display Clocks [Phase 2] / 2 Display Clocks [Phase 1])
-  //     D[3:0] => Phase 1 Period (discharge) in 1~15 Display Clocks
-  //     D[7:4] => Phase 2 Period (charge) in 1~15 Display Clocks
-
-  lcdSendCmd(SSD1309_CMD_SETVCOMDETECT);      // Set VCOMH Deselect Level
-  lcdSendCmd(0x00);      // 34  Default => 0x34 (0.78*VCC)
-
-  lcdSendCmd(SSD1309_CMD_NORMALDISPLAY); //--set normal display
-  lcdSendCmd(SSD1309_CMD_DISPLAYALLON);  //Disable Entire Display On
-  lcdSendCmd(SSD1309_CMD_DISPLAYWAKEUP); //--turn on oled panel
-  lcdSendCmd(SSD1309_CMD_DISPLAYALLON_RESUME); // Turn on OLED panel
-#else
-
-  lcdSendCmd(ST756n_CMD_RESET);
-  _delay_us(300);
-
-#if !defined (REVERSE_DISPLAY)
-  lcdSendCmd(ST756n_CMD_NORMAL_SEG_DIRECTION);
-  lcdSendCmd(ST756n_CMD_REVERSE_COM_DIRECTION);
-#else
-  lcdSendCmd(ST756n_CMD_REVERSE_SEG_DIRECTION);
-  lcdSendCmd(ST756n_CMD_NORMAL_COM_DIRECTION);
-#endif
-
-#if defined (LCD_ST7567)
-  lcdSendCmd(ST756n_CMD_SET_BOOSTER_LEVEL); lcdSendCmd(0); // Set Booster Level 4x.
-  lcdSendCmd(ST756n_CMD_BIAS_SELECT_7TH); // Select bias 1/7 (at 1/65 duty) not 1/9.
-  lcdSendCmd(ST756n_CMD_VOLTAGE_RESISTOR_RATIO_4dec5); // Compromise setting although contrast value could be 20 or 40.
-#endif
-
-#if defined (LCD_EVO)
-  lcdSendCmd(ST756n_CMD_VOLTAGE_RESISTOR_RATIO_5dec0);
-  lcdSendCmd(ST756n_CMD_CONTRAST_SET);
-  lcdSendCmd(20);
-
-#endif
-
-  lcdSendCmd(ST756n_CMD_POWER_CTRL | 4);
-  _delay_us(300);
-  lcdSendCmd(ST756n_CMD_POWER_CTRL | 6);
-  _delay_us(300);
-  lcdSendCmd(ST756n_CMD_POWER_CTRL | 7);
-  _delay_us(300);
-
-  lcdClearRAM();
-  lcdSendCmd(ST756n_CMD_DISPLAY_ON); // Display on.
-#endif
+  uint_farptr_t initseq = pgm_get_far_address(lcdInitSequence);
+  for (uint8_t i=0; i<DIM(lcdInitSequence); i++) {
+    lcdSendCmd(pgm_read_byte_far(initseq++));
+  }
 }
-
 
 volatile uint8_t * lcd_p = displayBuf;
 volatile uint8_t lcd_x_pos;
@@ -397,33 +391,35 @@ static void lcdRefreshFast()
 #endif
 #endif
 
-#if defined (LCD_SIZE_132X64)
-    lcdSendCmd(ST756n_CMD_COLUMN_ADDRESS_SET_LSB(2)); // Set LS nibble column RAM address 2
-#else
-    lcdSendCmd(ST756n_CMD_COLUMN_ADDRESS_SET_LSB(0)); // Set LS nibble column RAM address 0
-#endif
-    lcdSendCmd(ST756n_CMD_COLUMN_ADDRESS_SET_MSB(0)); // Set MS nibble column RAM address 0
-    lcdSendCmd(ST756n_CMD_PAGE_ADDRESS_SET(lcd_page ++));
+  lcdSendCmd(ST756n_CMD_COLUMN_ADDRESS_SET_LSB(0)); // Set LS nibble column RAM address 0
+  lcdSendCmd(ST756n_CMD_COLUMN_ADDRESS_SET_MSB(0)); // Set MS nibble column RAM address 0
+  lcdSendCmd(ST756n_CMD_PAGE_ADDRESS_SET(lcd_page ++));
 
 #if !defined (SPI9BIT)
-    LCD_CMD_DATA_HI;
+  LCD_CMD_DATA_HI;
 #endif
 
 #if defined(BITBANGSPI)
-    LCD_CS_ACTIVE;
+  LCD_CS_ACTIVE;
+#if defined (LCD_SIZE_132X64)
+lcd_spi_tx(0xff);
+lcd_spi_tx(0xff);
+#endif
+  for(lcd_x_pos = LCD_W; lcd_x_pos > 0; lcd_x_pos--) {
+    lcd_spi_tx( *lcd_p++ );
+  }
+#if defined (LCD_SIZE_132X64)
+lcd_spi_tx(0xff);
+lcd_spi_tx(0xff);
+#endif
 
-    for(lcd_x_pos = LCD_W; lcd_x_pos > 0; lcd_x_pos--) {
-      lcd_spi_tx( *lcd_p++ );
-    }
+  WAIT_LCD_TX_FIN;
+  LCD_CS_INACTIVE;
 
-    WAIT_LCD_TX_FIN;
-    LCD_CS_INACTIVE;
-
-    if (lcd_page > 7)
-    {
-      lcd_page = 0;
-      lcd_p = displayBuf;
-    }
+  if (lcd_page > 7) {
+    lcd_page = 0;
+    lcd_p = displayBuf;
+  }
 #else
     LCD_CS_ACTIVE;
     lcd_x_pos = LCD_W;
@@ -472,33 +468,3 @@ ISR(SPID_INT_vect)
   }
 }
 #endif
-
-
-static void lcdClearRAM(void)
-{
-  for(uint8_t page = 0; page < 8; page ++)
-    {
-      lcdSendCmd(ST756n_CMD_COLUMN_ADDRESS_SET_LSB(0)); // Set LS nibble column RAM address 0
-      lcdSendCmd(ST756n_CMD_COLUMN_ADDRESS_SET_MSB(0)); // Set MS nibble column RAM address 0
-      lcdSendCmd(ST756n_CMD_PAGE_ADDRESS_SET(page));
-
-#if !defined (SPI9BIT)
-    LCD_CMD_DATA_HI;
-#endif
-
-    LCD_CS_ACTIVE;
-
-#if defined (LCD_SIZE_132X64)
-      uint8_t column = 132;
-#else
-      uint8_t column = LCD_W; // 128.
-#endif
-
-      while(column--)  lcd_spi_tx(0x00);
-
-      WAIT_LCD_TX_FIN;
-      LCD_CS_INACTIVE;
-    }
-}
-
-

--- a/BootFramXM256x3/xboot.c
+++ b/BootFramXM256x3/xboot.c
@@ -296,6 +296,10 @@ protected = 1;
     }
 #endif // USE_ENTER_UART
 
+// Check for Application vector table.
+if ((pgm_read_byte_far(0x01)) != 0x94)
+  in_bootloader = 1;
+
   }
     // --------------------------------------------------
     // End main trigger section


### PR DESCRIPTION
Tidy code.
Fix pgm_read_byte_far() not working for xmega LCD initialisation array. Stay in Bootloader if no application vector found. Use Elevator Dual Rate switch for bootloader entry. for The Ingwies testing board.